### PR TITLE
fix: task table style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ Homestead.yaml
 Homestead.json
 /.vagrant
 .phpunit.result.cache
+
+/src/public/js/index.js.
+/src/public/mix-manifest.json

--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,3 +1,3 @@
 {
-    "/js/index.js": "/js/index.js?id=d33629d301b0b269aa6b32c4e0f44e05"
+    "/js/index.js": "/js/index.js?id=92eac284416443d562e3b41fab1f91e1"
 }

--- a/src/resources/ts/components/atomic/TasksTable.tsx
+++ b/src/resources/ts/components/atomic/TasksTable.tsx
@@ -21,10 +21,12 @@ type Props = {
     tasks: Array<Task>;
     isCheckbox: boolean;
     mt: string;
+    hTable: string;
+    hBody: string;
 };
 
 export const TasksTable = memo((props: Props) => {
-    const { tasks, isCheckbox, mt } = props;
+    const { tasks, isCheckbox, mt, hTable, hBody } = props;
     const [editTasks, setEditTasks] = useRecoilState(editTasksAtom);
     const [loading, setLoading] = useRecoilState(loadingAtom);
     const onChangeCheckbox = (e: ChangeEvent<HTMLInputElement>) => {
@@ -57,7 +59,7 @@ export const TasksTable = memo((props: Props) => {
                     xl: "1000px",
                     "2xl": "1200px",
                 }}
-                h="480px"
+                h={hTable}
                 mt={mt}
                 position="fixed"
             >
@@ -116,7 +118,6 @@ export const TasksTable = memo((props: Props) => {
                         </Tr>
                     </Thead>
                     <Tbody
-                        height="440px"
                         overflowY="scroll"
                         color="font.100"
                         borderColor="font.100"
@@ -129,6 +130,7 @@ export const TasksTable = memo((props: Props) => {
                             xl: "1000px",
                             "2xl": "1200px",
                         }}
+                        h={hBody}
                     >
                         {tasks.map((task) => (
                             <Tr
@@ -205,6 +207,7 @@ export const TasksTable = memo((props: Props) => {
                                     <Badge
                                         bgColor={task.priority}
                                         color="font.100"
+                                        w="60px"
                                     >
                                         {task.priority}
                                     </Badge>

--- a/src/resources/ts/components/organisms/home/WarningTask.tsx
+++ b/src/resources/ts/components/organisms/home/WarningTask.tsx
@@ -1,20 +1,32 @@
+import { Center, Spinner } from "@chakra-ui/react";
 import { memo, useEffect } from "react";
 import { useWarningTasks } from "../../../hooks/useWarningTasks";
 import { ItemHeader } from "../../atomic/ItemHeader";
 import { TasksTable } from "../../atomic/TasksTable";
 
 export const WarningTask = memo(() => {
-    const { getTasks, tasks } = useWarningTasks();
+    const { getTasks, tasks, loading } = useWarningTasks();
 
     useEffect(() => {
         getTasks();
-        console.log(tasks);
     }, []);
 
     return (
         <>
             <ItemHeader text="Warning Task" borderColor="main.2.100" />
-            <TasksTable tasks={tasks} isCheckbox={false} mt="50px" />
+            {loading ? (
+                <Center>
+                    <Spinner />
+                </Center>
+            ) : (
+                <TasksTable
+                    tasks={tasks}
+                    isCheckbox={false}
+                    mt="50px"
+                    hTable="200px"
+                    hBody="160px"
+                />
+            )}
         </>
     );
 });

--- a/src/resources/ts/components/pages/TaskPage.tsx
+++ b/src/resources/ts/components/pages/TaskPage.tsx
@@ -85,6 +85,8 @@ export const TaskPage = memo(() => {
                         tasks={tasks}
                         isCheckbox={!isOpen}
                         mt={isOpen ? "320px" : "50px"}
+                        hTable={isOpen ? "315px" : "480px"}
+                        hBody={isOpen ? "275px" : "440px"}
                     />
                 </>
             )}

--- a/src/resources/ts/hooks/useWarningTasks.ts
+++ b/src/resources/ts/hooks/useWarningTasks.ts
@@ -4,12 +4,19 @@ import { Task } from "../types/task";
 
 export const useWarningTasks = () => {
     const [tasks, setTasks] = useState<Array<Task>>([]);
+    const [loading, setLoading] = useState<boolean>(false);
 
     const getTasks = useCallback(() => {
-        axios.get<Array<Task>>("/api/home").then((res) => {
-            setTasks(res.data);
-        });
+        setLoading(true);
+        axios
+            .get<Array<Task>>("/api/home")
+            .then((res) => {
+                setTasks(res.data);
+            })
+            .finally(() => {
+                setLoading(false);
+            });
     }, []);
 
-    return { getTasks, tasks };
+    return { getTasks, tasks, loading };
 };


### PR DESCRIPTION
１．HomeページでタスクをAPIで取得している間、ロード画面を表示するように変更しました。
２．Taskページでタスクを追加するエリアを表示するときにタスクテーブルの高さを小さくする処理を追加しました。 
３．タスクテーブルのpriorityのバッジの横幅を統一しました。

 Changes to be committed:
	modified:   .gitignore
	modified:   src/public/js/index.js
	modified:   src/public/mix-manifest.json
	modified:   src/resources/ts/components/atomic/TasksTable.tsx
	modified:   src/resources/ts/components/organisms/home/WarningTask.tsx
	modified:   src/resources/ts/components/pages/TaskPage.tsx
	modified:   src/resources/ts/hooks/useWarningTasks.ts