### PR TITLE
add: show finished task

### DIFF
--- a/src/app/Http/Controllers/TaskController.php
+++ b/src/app/Http/Controllers/TaskController.php
@@ -15,6 +15,13 @@ class TaskController extends Controller
         return response()->json($tasks);
     }
 
+    public function getFinishedTask()
+    {
+        $task_model = new Task();
+        $tasks = $task_model->getFinishedTask(1);
+        return response()->json($tasks);
+    }
+
     public function store(Request $request)
     {
         $new_task = new Task();
@@ -27,7 +34,8 @@ class TaskController extends Controller
         $new_task->save();
     }
 
-    public function update(Request $request){
+    public function update(Request $request)
+    {
         $task = Task::find($request->id);
         $task->title = $request->title;
         $task->due = $request->due;
@@ -43,7 +51,7 @@ class TaskController extends Controller
         foreach ($task_id_ary as $task_id) {
             try {
                 $task = Task::find($task_id);
-                $task->is_finished = 1;
+                $task->is_finished = !$task->is_finished;
                 $task->save();
             } catch (Exception $err) {
                 return response()->json($err);

--- a/src/app/Models/Task.php
+++ b/src/app/Models/Task.php
@@ -16,25 +16,37 @@ class Task extends Model
 
     protected $table = 'task';
 
-    function getWarningTask($user_id){
+    function getWarningTask($user_id)
+    {
         $tasks = $this
             ->where('user_id', $user_id)
             ->where('is_finished', 0)
             ->where('deleted_at', null)
-            ->where(function($query){
+            ->where(function ($query) {
                 $today = new Carbon('today');
                 $next_week = new Carbon('+1 week');
                 $query->where('priority', 'high')
-                ->orWhereBetween('due', [$today, $next_week]);
+                    ->orWhereBetween('due', [$today, $next_week]);
             })
             ->get();
         return $tasks;
     }
 
-    function getTask($user_id){
+    function getTask($user_id)
+    {
         $tasks = $this
             ->where('user_id', $user_id)
             ->where('is_finished', 0)
+            ->where('deleted_at', null)
+            ->get();
+        return $tasks;
+    }
+
+    function getFinishedTask($user_id)
+    {
+        $tasks = $this
+            ->where('user_id', $user_id)
+            ->where('is_finished', 1)
             ->where('deleted_at', null)
             ->get();
         return $tasks;

--- a/src/resources/ts/components/atomic/task/FinishedTaskSwitch.tsx
+++ b/src/resources/ts/components/atomic/task/FinishedTaskSwitch.tsx
@@ -1,0 +1,35 @@
+import { FormControl, FormLabel, Switch } from "@chakra-ui/react";
+import { memo } from "react";
+import { useRecoilState } from "recoil";
+import { isFinishedTaskAtom } from "../../../recoil/isFinishedTaskAtom";
+
+export const FinishedTaskSwitch = memo(() => {
+    const [isFinishedTask, setIsFinishedTask] =
+        useRecoilState(isFinishedTaskAtom);
+    const onChange = () => {
+        setIsFinishedTask((oldIsFinishedTask) => {
+            return !oldIsFinishedTask;
+        });
+    };
+    return (
+        <FormControl
+            display="flex"
+            alignItems="center"
+            w={{ sm: "40px", md: "200px", lg: "250px" }}
+        >
+            <FormLabel
+                htmlFor="show-finished-task"
+                mb="0"
+                display={{ sm: "none", md: "block" }}
+            >
+                Show Finished Task
+            </FormLabel>
+            <Switch
+                id="show-finished-task"
+                size="sm"
+                defaultChecked={isFinishedTask}
+                onChange={onChange}
+            />
+        </FormControl>
+    );
+});

--- a/src/resources/ts/components/atomic/task/OrderRadioGroup.tsx
+++ b/src/resources/ts/components/atomic/task/OrderRadioGroup.tsx
@@ -11,11 +11,12 @@ export const OrderRadioGroup = memo((props: Props) => {
 
     return (
         <RadioGroup
+            alignItems="center"
             defaultValue="1"
             onChange={onClickRadio}
             isDisabled={isDisabled}
         >
-            <Stack spacing={5} direction="row">
+            <Stack spacing={5} direction="row" h="40px">
                 <Radio value="1">Asc</Radio>
                 <Radio value="2">Desc</Radio>
             </Stack>

--- a/src/resources/ts/components/organisms/task/TaskHeader.tsx
+++ b/src/resources/ts/components/organisms/task/TaskHeader.tsx
@@ -1,11 +1,12 @@
-import { Select, Stack } from "@chakra-ui/react";
-import { memo, ReactNode } from "react";
+import { Stack } from "@chakra-ui/react";
+import { memo } from "react";
 import { useRecoilState } from "recoil";
 import { iconManager } from "../../../icon";
 import { loadingAtom } from "../../../recoil/isLoadingAtom";
 import { PrimaryButton } from "../../atomic/buttons/PrimaryButton";
 import { OrderSelectBox } from "../../atomic/task/OrderSelectBox";
 import { OrderRadioGroup } from "../../atomic/task/OrderRadioGroup";
+import { FinishedTaskSwitch } from "../../atomic/task/FinishedTaskSwitch";
 
 type Props = {
     onClickRadio: () => void;
@@ -41,6 +42,7 @@ export const TaskHeader = memo((props: Props) => {
             position="fixed"
             justifyContent="space-between"
             overflowX="scroll"
+            alignItems="center"
         >
             <Stack w="80px">
                 {showAddBtn ? (
@@ -58,7 +60,8 @@ export const TaskHeader = memo((props: Props) => {
                 )}
             </Stack>
 
-            <Stack textAlign="right" direction="row">
+            <Stack textAlign="right" direction="row" h="40px">
+                <FinishedTaskSwitch />
                 <OrderRadioGroup
                     onClickRadio={onClickRadio}
                     isDisabled={loading}

--- a/src/resources/ts/components/pages/TaskPage.tsx
+++ b/src/resources/ts/components/pages/TaskPage.tsx
@@ -3,6 +3,7 @@ import { memo, useEffect, useState } from "react";
 import { useRecoilState } from "recoil";
 import { useTasks } from "../../hooks/useTasks";
 import { isChangedTaskAtom } from "../../recoil/isChangedTaskAtom";
+import { isFinishedTaskAtom } from "../../recoil/isFinishedTaskAtom";
 import { loadingAtom } from "../../recoil/isLoadingAtom";
 import { Task } from "../../types/task";
 import { TasksTable } from "../molecules/TasksTable";
@@ -10,6 +11,7 @@ import { TaskAdd } from "../organisms/task/TaskAdd";
 import { TaskHeader } from "../organisms/task/TaskHeader";
 
 export const TaskPage = memo(() => {
+    const [isFinishedTask] = useRecoilState(isFinishedTaskAtom);
     const { tasks, getTasks, setTasks, firstLoading } = useTasks();
     const [isDesc, setIsDesc] = useState<boolean>(false);
     const { isOpen, onOpen, onClose } = useDisclosure();
@@ -17,8 +19,8 @@ export const TaskPage = memo(() => {
     const [loading, setLoading] = useRecoilState(loadingAtom);
 
     useEffect(() => {
-        getTasks();
-    }, [isChangedTask]);
+        getTasks(isFinishedTask);
+    }, [isChangedTask, isFinishedTask]);
 
     const reverseTasks = () => {
         setLoading(true);

--- a/src/resources/ts/hooks/useTasks.ts
+++ b/src/resources/ts/hooks/useTasks.ts
@@ -6,21 +6,39 @@ export const useTasks = () => {
     const [tasks, setTasks] = useState<Array<Task>>([]);
     const [firstLoading, setFirstLoading] = useState<boolean>(false);
 
-    const getTasks = useCallback(() => {
+    const getTasks = useCallback((isFinishedTask: boolean) => {
         setFirstLoading(true);
-        axios
-            .get<Array<Task>>("/api/task")
-            .then((res) => {
-                setTasks(
-                    res.data.sort((a, b) => {
-                        if (a.due > b.due) return 1;
-                        return -1;
-                    })
-                );
-            })
-            .finally(() => {
-                setFirstLoading(false);
-            });
+        if (isFinishedTask) {
+            console.log("finished");
+            axios
+                .get<Array<Task>>("/api/task/finished")
+                .then((res) => {
+                    setTasks(
+                        res.data.sort((a, b) => {
+                            if (a.due > b.due) return 1;
+                            return -1;
+                        })
+                    );
+                })
+                .finally(() => {
+                    setFirstLoading(false);
+                });
+        } else {
+            console.log("Not finished");
+            axios
+                .get<Array<Task>>("/api/task")
+                .then((res) => {
+                    setTasks(
+                        res.data.sort((a, b) => {
+                            if (a.due > b.due) return 1;
+                            return -1;
+                        })
+                    );
+                })
+                .finally(() => {
+                    setFirstLoading(false);
+                });
+        }
     }, []);
 
     return { getTasks, tasks, setTasks, firstLoading };

--- a/src/resources/ts/recoil/isFinishedTaskAtom.ts
+++ b/src/resources/ts/recoil/isFinishedTaskAtom.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const isFinishedTaskAtom = atom({
+    key: "isFinishedTaskAtom",
+    default: false,
+});

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -21,6 +21,7 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 Route::group(['middleware' => 'api'], function () {
     Route::get('home', 'App\Http\Controllers\HomeController@index');
     Route::get('task', 'App\Http\Controllers\TaskController@index');
+    Route::get('task/finished', 'App\Http\Controllers\TaskController@getFinishedTask');
     Route::post('task/store', 'App\Http\Controllers\TaskController@store');
     Route::put('task/update', 'App\Http\Controllers\TaskController@update');
     Route::put('task/finish', 'App\Http\Controllers\TaskController@finish');


### PR DESCRIPTION
１．タスクページのヘッダーに終了したタスクを表示するスイッチを追加しました。
２．終了したタスクを表示する機能を追加しました。それにともないタスクの編集機能を修正しました。
３．タスクのヘッダーのスタイルを調整しました。
 Changes to be committed:
	modified:   src/app/Http/Controllers/TaskController.php
	modified:   src/app/Models/Task.php
	new file:   src/resources/ts/components/atomic/task/FinishedTaskSwitch.tsx
	modified:   src/resources/ts/components/atomic/task/OrderRadioGroup.tsx
	modified:   src/resources/ts/components/organisms/task/TaskHeader.tsx
	modified:   src/resources/ts/components/pages/TaskPage.tsx
	modified:   src/resources/ts/hooks/useTasks.ts
	new file:   src/resources/ts/recoil/isFinishedTaskAtom.ts
	modified:   src/routes/api.php