### PR TITLE
fix: task table style

### DIFF
--- a/src/resources/ts/components/atomic/task/FinishedTaskSwitch.tsx
+++ b/src/resources/ts/components/atomic/task/FinishedTaskSwitch.tsx
@@ -15,12 +15,12 @@ export const FinishedTaskSwitch = memo(() => {
         <FormControl
             display="flex"
             alignItems="center"
-            w={{ sm: "40px", md: "200px", lg: "250px" }}
+            w={{ sm: "40px", md: "50px", lg: "250px" }}
         >
             <FormLabel
                 htmlFor="show-finished-task"
                 mb="0"
-                display={{ sm: "none", md: "block" }}
+                display={{ sm: "none", md: "none", lg: "block" }}
             >
                 Show Finished Task
             </FormLabel>

--- a/src/resources/ts/components/atomic/task/OrderSelectBox.tsx
+++ b/src/resources/ts/components/atomic/task/OrderSelectBox.tsx
@@ -22,7 +22,7 @@ export const OrderSelectBox = memo((props: Props) => {
     return (
         <Select
             size="sm"
-            w="200px"
+            w={{ sm: "100px", md: "200px" }}
             bgColor="main.1"
             onChange={(e) => order(e)}
             defaultValue="Due"

--- a/src/resources/ts/components/organisms/home/WarningTask.tsx
+++ b/src/resources/ts/components/organisms/home/WarningTask.tsx
@@ -15,7 +15,7 @@ export const WarningTask = memo(() => {
         <>
             <ItemHeader text="Warning Task" borderColor="main.2.100" />
             {loading ? (
-                <Center>
+                <Center mt="200px">
                     <Spinner />
                 </Center>
             ) : (

--- a/src/resources/ts/components/organisms/task/TaskHeader.tsx
+++ b/src/resources/ts/components/organisms/task/TaskHeader.tsx
@@ -29,10 +29,10 @@ export const TaskHeader = memo((props: Props) => {
     const [loading] = useRecoilState(loadingAtom);
     return (
         <Stack
-            spacing={5}
+            spacing={{ sm: "0", md: "5" }}
             direction="row"
             w={{
-                sm: "330px",
+                sm: "400px",
                 md: "610px",
                 lg: "800px",
                 xl: "1000px",
@@ -41,7 +41,7 @@ export const TaskHeader = memo((props: Props) => {
             h="40px"
             position="fixed"
             justifyContent="space-between"
-            overflowX="scroll"
+            overflowX="auto"
             alignItems="center"
         >
             <Stack w="80px">

--- a/src/resources/ts/components/pages/TaskPage.tsx
+++ b/src/resources/ts/components/pages/TaskPage.tsx
@@ -69,7 +69,7 @@ export const TaskPage = memo(() => {
     return (
         <>
             {firstLoading ? (
-                <Center>
+                <Center mt="200px">
                     <Spinner />
                 </Center>
             ) : (


### PR DESCRIPTION
１．タスクページのヘッダーをx方向にスクロールしないようにレスポンシブデザインを修正しました。
２．タスク取得中のスピナーの上部に余白を追加しました。
 Changes to be committed:
	modified:   src/resources/ts/components/atomic/task/FinishedTaskSwitch.tsx
	modified:   src/resources/ts/components/atomic/task/OrderSelectBox.tsx
	modified:   src/resources/ts/components/organisms/home/WarningTask.tsx
	modified:   src/resources/ts/components/organisms/task/TaskHeader.tsx
	modified:   src/resources/ts/components/pages/TaskPage.tsx