### PR TITLE
change: edit schedule atom

### DIFF
--- a/src/resources/ts/components/organisms/gantt/Chart.tsx
+++ b/src/resources/ts/components/organisms/gantt/Chart.tsx
@@ -9,7 +9,7 @@ import {
 } from "gantt-task-react";
 import "gantt-task-react/dist/index.css";
 import { useRecoilState } from "recoil";
-import { editScheduleAtom } from "../../../recoil/editScheduleAtom";
+import { scheduleAtom } from "../../../recoil/scheduleAtom";
 import { ScheduleModal } from "./ScheduleModal";
 
 type Props = {
@@ -19,7 +19,7 @@ type Props = {
 export const Chart = (props: Props) => {
     const { schedules } = props;
     const { isOpen, onOpen, onClose } = useDisclosure();
-    const [editSchedule, setEditSchedule] = useRecoilState(editScheduleAtom);
+    const [editSchedule, setEditSchedule] = useRecoilState(scheduleAtom);
 
     const onClick = (task: Task) => {
         setEditSchedule(task);

--- a/src/resources/ts/components/organisms/gantt/ScheduleEditForm.tsx
+++ b/src/resources/ts/components/organisms/gantt/ScheduleEditForm.tsx
@@ -10,7 +10,7 @@ import { ChangeEvent } from "react";
 import { useRecoilState } from "recoil";
 import { useSchedule } from "../../../hooks/useSchedule";
 import { iconManager } from "../../../icon";
-import { editScheduleAtom } from "../../../recoil/editScheduleAtom";
+import { scheduleAtom } from "../../../recoil/scheduleAtom";
 import { CancelButton } from "../../atomic/buttons/CancelButton";
 import { PrimaryButton } from "../../atomic/buttons/PrimaryButton";
 
@@ -22,7 +22,7 @@ type Props = {
 export const ScheduleEditForm = (props: Props) => {
     const { schedule, onClose } = props;
     const { updateSchedule, loading } = useSchedule();
-    const [editSchedule, setEditSchedule] = useRecoilState(editScheduleAtom);
+    const [editSchedule, setEditSchedule] = useRecoilState(scheduleAtom);
     const onChangeTitle = (e: ChangeEvent<HTMLInputElement>) => {
         setEditSchedule({ ...editSchedule, name: e.target.value });
     };
@@ -33,7 +33,7 @@ export const ScheduleEditForm = (props: Props) => {
         setEditSchedule({ ...editSchedule, end: new Date(e.target.value) });
     };
     const onClickUpdate = () => {
-        updateSchedule({ ...editSchedule });
+        updateSchedule();
     };
     return (
         <>

--- a/src/resources/ts/hooks/useSchedule.ts
+++ b/src/resources/ts/hooks/useSchedule.ts
@@ -4,6 +4,7 @@ import { Task } from "gantt-task-react";
 import { useState } from "react";
 import { useRecoilState } from "recoil";
 import { isChangedAtom } from "../recoil/isChangedAtom";
+import { scheduleAtom } from "../recoil/scheduleAtom";
 import { Schedule } from "../types/schedule";
 
 type promiseType = (data: Array<any>) => void;
@@ -13,6 +14,7 @@ export const useSchedule = () => {
     const [schedulesLoading, setSchedulesLoading] = useState<boolean>(false);
     const [loading, setLoading] = useState<boolean>(false);
     const [isChanged, setIsChanged] = useRecoilState(isChangedAtom);
+    const [editSchedule, setEditSchedule] = useRecoilState(scheduleAtom);
     const toast = useToast();
     const getSchedules = () => {
         return new Promise((resolve: promiseType, reject: promiseType) => {
@@ -27,12 +29,12 @@ export const useSchedule = () => {
         });
     };
 
-    const updateSchedule = (schedule: Task) => {
+    const updateSchedule = () => {
         setLoading(true);
         const castedSchedule = {
-            ...schedule,
-            start: schedule.start.toISOString().split("T")[0],
-            end: schedule.end.toISOString().split("T")[0],
+            ...editSchedule,
+            start: editSchedule.start.toISOString().split("T")[0],
+            end: editSchedule.end.toISOString().split("T")[0],
         };
         axios
             .put("/api/schedule/update", castedSchedule)
@@ -43,6 +45,14 @@ export const useSchedule = () => {
                     duration: 5000,
                     isClosable: true,
                     position: "top-right",
+                });
+                setEditSchedule({
+                    start: new Date(2020, 1, 1),
+                    end: new Date(2020, 1, 2),
+                    name: "Idea",
+                    id: "Task 0",
+                    type: "task",
+                    progress: 100,
                 });
             })
             .catch((err) => {

--- a/src/resources/ts/recoil/scheduleAtom.ts
+++ b/src/resources/ts/recoil/scheduleAtom.ts
@@ -1,8 +1,8 @@
 import { Task } from "gantt-task-react";
 import { atom } from "recoil";
 
-export const editScheduleAtom = atom({
-    key: "editScheduleAtom",
+export const scheduleAtom = atom({
+    key: "ScheduleAtom",
     default: <Task>{
         start: new Date(2020, 1, 1),
         end: new Date(2020, 1, 2),


### PR DESCRIPTION
１．editScheduleAtomをスケジュールの更新処理だけなく、他の処理でも使用するためにファイル名やkeyを変更しました。 
２．useSchedule中のスケジュールの更新処理関数の引数を削除し、その処理にはリコイルをインポートして使用するように修正しました。
 Changes to be committed:
	modified:   src/resources/ts/components/organisms/gantt/Chart.tsx
	modified:   src/resources/ts/components/organisms/gantt/ScheduleEditForm.tsx
	modified:   src/resources/ts/hooks/useSchedule.ts
	renamed:    src/resources/ts/recoil/editScheduleAtom.ts -> src/resources/ts/recoil/scheduleAtom.ts