### PR TITLE
change: Ganttchart Display

### DIFF
--- a/src/resources/ts/components/organisms/gantt/Chart.tsx
+++ b/src/resources/ts/components/organisms/gantt/Chart.tsx
@@ -14,10 +14,11 @@ import { ScheduleModal } from "./ScheduleModal";
 
 type Props = {
     schedules: Array<any>;
+    displayDate: Date;
 };
 
 export const Chart = (props: Props) => {
-    const { schedules } = props;
+    const { schedules, displayDate } = props;
     const { isOpen, onOpen, onClose } = useDisclosure();
     const [editSchedule, setEditSchedule] = useRecoilState(scheduleAtom);
 
@@ -43,6 +44,7 @@ export const Chart = (props: Props) => {
                 tasks={schedules}
                 listCellWidth=""
                 ganttHeight={500}
+                viewDate={displayDate}
                 todayColor="rgba(2, 62, 138, 0.5)"
                 onClick={onClick}
             />

--- a/src/resources/ts/components/organisms/gantt/ScheduleEditForm.tsx
+++ b/src/resources/ts/components/organisms/gantt/ScheduleEditForm.tsx
@@ -43,6 +43,7 @@ export const ScheduleEditForm = (props: Props) => {
             <ModalBody justifyContent="space-around" h="120px">
                 <Stack direction="row" h="40px" my="20px" justifyContent="space-around">
                     <Input
+                        isDisabled={loading}
                         defaultValue={schedule.name}
                         onChange={onChangeTitle}
                     />
@@ -50,6 +51,7 @@ export const ScheduleEditForm = (props: Props) => {
                 <Stack direction="row" h="40px" justifyContent="space-around">
                     <Input
                         type="date"
+                        isDisabled={loading}
                         defaultValue={
                             schedule.start.toISOString().split("T")[0]
                         }
@@ -57,6 +59,7 @@ export const ScheduleEditForm = (props: Props) => {
                     />
                     <Input
                         type="date"
+                        isDisabled={loading}
                         defaultValue={schedule.end.toISOString().split("T")[0]}
                         onChange={onChangeEnd}
                     />

--- a/src/resources/ts/components/pages/Gantt.tsx
+++ b/src/resources/ts/components/pages/Gantt.tsx
@@ -19,8 +19,14 @@ export const Gantt = memo(() => {
         },
     ]);
     const [isChanged] = useRecoilState(isChangedAtom);
+    const [displayDate ,setDisplayDate] = useState<Date>(new Date());
     useEffect(() => {
         setLoading(true);
+        setDisplayDate( () => {
+            const date = new Date();
+            date.setDate(date.getDate() + -4);
+            return date;
+        } );
         getSchedules().then((schedules) => {
             let newSchedules: any[] = [];
             schedules.forEach((schedule) => {
@@ -42,7 +48,7 @@ export const Gantt = memo(() => {
                     <Spinner />
                 </Center>
             ) : (
-                <Chart schedules={schedules} />
+                <Chart schedules={schedules} displayDate={displayDate} />
             )}
         </>
     );


### PR DESCRIPTION
１．ガントチャートページの表示時にその日のスケジュールの周辺が表示されるように変更しました。
２．スケジュールの更新処理時にフォームに入力できないように変更しました。
 Changes to be committed:
	modified:   src/resources/ts/components/organisms/gantt/Chart.tsx
	modified:   src/resources/ts/components/organisms/gantt/ScheduleEditForm.tsx
	modified:   src/resources/ts/components/pages/Gantt.tsx