### PR TITLE
add: create schedule modal

### DIFF
--- a/src/resources/ts/components/organisms/gantt/Chart.tsx
+++ b/src/resources/ts/components/organisms/gantt/Chart.tsx
@@ -8,8 +8,11 @@ import {
     DisplayOption,
 } from "gantt-task-react";
 import "gantt-task-react/dist/index.css";
+import { useState } from "react";
 import { useRecoilState } from "recoil";
+import { iconManager } from "../../../icon";
 import { scheduleAtom } from "../../../recoil/scheduleAtom";
+import { PrimaryButton } from "../../atomic/buttons/PrimaryButton";
 import { ScheduleModal } from "./ScheduleModal";
 
 type Props = {
@@ -19,10 +22,17 @@ type Props = {
 
 export const Chart = (props: Props) => {
     const { schedules, displayDate } = props;
+    const [isUpdate, setIsUpdate] = useState<boolean>(false);
     const { isOpen, onOpen, onClose } = useDisclosure();
     const [editSchedule, setEditSchedule] = useRecoilState(scheduleAtom);
 
-    const onClick = (task: Task) => {
+    const onClickAdd = () => {
+        setIsUpdate(false);
+        onOpen();
+    };
+
+    const onClickTask = (task: Task) => {
+        setIsUpdate(true);
         setEditSchedule(task);
         onOpen();
     };
@@ -37,22 +47,43 @@ export const Chart = (props: Props) => {
                 "2xl": "1200px",
             }}
             h="500px"
+            p="5px"
             color="font.100"
-            bgColor="main.2.100"
         >
+            <Stack
+                direction="row"
+                w={{
+                    sm: "400px",
+                    md: "610px",
+                    lg: "800px",
+                    xl: "1000px",
+                    "2xl": "1200px",
+                }}
+                h="60px"
+            >
+                <PrimaryButton
+                    leftIcon={iconManager.add}
+                    size="sm"
+                    isDisabled={false}
+                    isLoading={false}
+                    onClick={onClickAdd}
+                >
+                    Add
+                </PrimaryButton>
+            </Stack>
             <Gantt
                 tasks={schedules}
                 listCellWidth=""
                 ganttHeight={500}
                 viewDate={displayDate}
                 todayColor="rgba(2, 62, 138, 0.5)"
-                onClick={onClick}
+                onClick={onClickTask}
             />
 
             <ScheduleModal
                 isOpen={isOpen}
                 onClose={onClose}
-                isUpdate={true}
+                isUpdate={isUpdate}
                 schedule={editSchedule}
             />
         </Stack>

--- a/src/resources/ts/components/organisms/gantt/ScheduleCreateForm.tsx
+++ b/src/resources/ts/components/organisms/gantt/ScheduleCreateForm.tsx
@@ -1,0 +1,81 @@
+import {
+    Input,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+    Stack,
+} from "@chakra-ui/react";
+import { ChangeEvent } from "react";
+import { useRecoilState } from "recoil";
+import { useSchedule } from "../../../hooks/useSchedule";
+import { iconManager } from "../../../icon";
+import { scheduleAtom } from "../../../recoil/scheduleAtom";
+import { CancelButton } from "../../atomic/buttons/CancelButton";
+import { PrimaryButton } from "../../atomic/buttons/PrimaryButton";
+
+type Props = {
+    onClose: () => void;
+};
+
+export const ScheduleCreateForm = (props: Props) => {
+    const { onClose } = props;
+    const { loading } = useSchedule();
+    const [editSchedule, setEditSchedule] = useRecoilState(scheduleAtom);
+    const onChangeTitle = (e: ChangeEvent<HTMLInputElement>) => {
+        setEditSchedule({ ...editSchedule, name: e.target.value });
+    };
+    const onChangeStart = (e: ChangeEvent<HTMLInputElement>) => {
+        setEditSchedule({ ...editSchedule, start: new Date(e.target.value) });
+    };
+    const onChangeEnd = (e: ChangeEvent<HTMLInputElement>) => {
+        setEditSchedule({ ...editSchedule, end: new Date(e.target.value) });
+    };
+    const onClickStore = () => {
+    };
+    return (
+        <>
+            <ModalHeader color="font.100" h="80px">
+                Schedule Add
+            </ModalHeader>
+            <ModalBody justifyContent="space-around" h="120px">
+                <Stack direction="row" h="40px" my="20px" justifyContent="space-around">
+                    <Input
+                        placeholder="title"
+                        isDisabled={loading}
+                        onChange={onChangeTitle}
+                    />
+                </Stack>
+                <Stack direction="row" h="40px" justifyContent="space-around">
+                    <Input
+                        type="date"
+                        isDisabled={loading}
+                        onChange={onChangeStart}
+                    />
+                    <Input
+                        type="date"
+                        isDisabled={loading}
+                        onChange={onChangeEnd}
+                    />
+                </Stack>
+            </ModalBody>
+            <ModalFooter>
+                <Stack direction="row">
+                    <PrimaryButton
+                        onClick={onClickStore}
+                        size="sm"
+                        isDisabled={editSchedule.name == ""}
+                        isLoading={loading}
+                        leftIcon={iconManager.check}
+                    >
+                        OK
+                    </PrimaryButton>
+                    <CancelButton
+                        onClick={onClose}
+                        size="sm"
+                        isDisabled={loading}
+                    />
+                </Stack>
+            </ModalFooter>
+        </>
+    );
+};

--- a/src/resources/ts/components/organisms/gantt/ScheduleModal.tsx
+++ b/src/resources/ts/components/organisms/gantt/ScheduleModal.tsx
@@ -1,5 +1,6 @@
 import { Modal, ModalContent, ModalOverlay } from "@chakra-ui/react";
 import { Task } from "gantt-task-react";
+import { ScheduleCreateForm } from "./ScheduleCreateForm";
 import { ScheduleEditForm } from "./ScheduleEditForm";
 
 type Props = {
@@ -27,7 +28,7 @@ export const ScheduleModal = (props: Props) => {
                             onClose={onClose}
                         />
                     ) : (
-                        <></>
+                        <ScheduleCreateForm onClose={onClose} />
                     )}
                 </ModalContent>
             </Modal>


### PR DESCRIPTION
１．スケジュールを作成するフォームを作成しました。
２．クリックするコンテンツによって、表示されるモーダルの内容がスケジュールの編集フォームと作成フォームが切り替わるように変更しました。
 Changes to be committed:
	modified:   src/resources/ts/components/organisms/gantt/Chart.tsx
	new file:   src/resources/ts/components/organisms/gantt/ScheduleCreateForm.tsx
	modified:   src/resources/ts/components/organisms/gantt/ScheduleModal.tsx