### PR TITLE
add: create schedule api

### DIFF
--- a/src/app/Http/Controllers/ScheduleController.php
+++ b/src/app/Http/Controllers/ScheduleController.php
@@ -16,12 +16,41 @@ class ScheduleController extends Controller
         return response()->json($schedules);
     }
 
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'name' => ['required', 'string', 'max:63',],
+            'start' => ['required', 'date',],
+            'end' => ['required', 'date', 'after_or_equal:start',]
+        ]);
+
+        if ($validator->fails()) {
+            $errors = $validator->errors()->toArray();
+            $response['errors'] = ['name' => [], 'start_date' => [], 'end_date' => [],];
+            foreach ($errors as $error_key => $error) {
+                $response['errors'][$error_key] = $error;
+            };
+            return response()->json($request, 401);
+        }
+        try {
+            $schedule = new Schedule();
+            $schedule->title = $request->name;
+            $schedule->start_date = $request->start;
+            $schedule->end_date = $request->end;
+            $schedule->type = 'task';
+            $schedule->progress = 100;
+            $schedule->save();
+        } catch (Exception $err) {
+            return response()->json([], 401);
+        };
+    }
+
     public function update(Request $request)
     {
         $validator = Validator::make($request->all(), [
-            'name' => ['required', 'string', 'max:63'],
+            'name' => ['required', 'string', 'max:63',],
             'start' => ['required', 'date',],
-            'end' => ['required', 'date',]
+            'end' => ['required', 'date', 'after_or_equal:start',]
         ]);
 
         if ($validator->fails()) {

--- a/src/resources/ts/components/organisms/gantt/ScheduleCreateForm.tsx
+++ b/src/resources/ts/components/organisms/gantt/ScheduleCreateForm.tsx
@@ -19,7 +19,7 @@ type Props = {
 
 export const ScheduleCreateForm = (props: Props) => {
     const { onClose } = props;
-    const { loading } = useSchedule();
+    const { storeSchedule, loading } = useSchedule();
     const [editSchedule, setEditSchedule] = useRecoilState(scheduleAtom);
     const onChangeTitle = (e: ChangeEvent<HTMLInputElement>) => {
         setEditSchedule({ ...editSchedule, name: e.target.value });
@@ -31,6 +31,7 @@ export const ScheduleCreateForm = (props: Props) => {
         setEditSchedule({ ...editSchedule, end: new Date(e.target.value) });
     };
     const onClickStore = () => {
+        storeSchedule();
     };
     return (
         <>
@@ -38,7 +39,12 @@ export const ScheduleCreateForm = (props: Props) => {
                 Schedule Add
             </ModalHeader>
             <ModalBody justifyContent="space-around" h="120px">
-                <Stack direction="row" h="40px" my="20px" justifyContent="space-around">
+                <Stack
+                    direction="row"
+                    h="40px"
+                    my="20px"
+                    justifyContent="space-around"
+                >
                     <Input
                         placeholder="title"
                         isDisabled={loading}

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -34,5 +34,6 @@ Route::group(['middleware' => 'auth:sanctum'], function () {
     Route::put('task/finish', 'App\Http\Controllers\TaskController@finish');
     Route::put('task/delete', 'App\Http\Controllers\TaskController@delete');
     Route::get('schedules', 'App\Http\Controllers\ScheduleController@index');
+    Route::post('schedule/store', 'App\Http\Controllers\ScheduleController@store');
     Route::put('schedule/update', 'App\Http\Controllers\ScheduleController@update');
 });


### PR DESCRIPTION
１．スケジュールを作成するAPIを作成しました。
２．スケジュールを作成するためのhooksを作成しました。
３．スケジュールの作成処理の追加とともに、スケジュールの更新時のバリデーションを修正しました。
４．スケジュールの作成モーダル内のcreateボタンのイベントが発火するように変更しました。
 Changes to be committed:
	modified:   src/app/Http/Controllers/ScheduleController.php
	modified:   src/resources/ts/components/organisms/gantt/ScheduleCreateForm.tsx
	modified:   src/resources/ts/hooks/useSchedule.ts
	modified:   src/routes/api.php