### PR TITLE
add: delete schedule api

### DIFF
--- a/src/app/Http/Controllers/ScheduleController.php
+++ b/src/app/Http/Controllers/ScheduleController.php
@@ -71,4 +71,15 @@ class ScheduleController extends Controller
             return response()->json([], 401);
         };
     }
+
+    public function delete(Request $request)
+    {
+        $schedule_id = $request->id;
+        try {
+            $schedule = Schedule::find($schedule_id);
+            $schedule->delete();
+        } catch (Exception $err) {
+            return response()->json($err, 401);
+        }
+    }
 }

--- a/src/resources/ts/components/organisms/gantt/ScheduleEditForm.tsx
+++ b/src/resources/ts/components/organisms/gantt/ScheduleEditForm.tsx
@@ -22,7 +22,7 @@ type Props = {
 
 export const ScheduleEditForm = (props: Props) => {
     const { schedule, onClose } = props;
-    const { updateSchedule, loading } = useSchedule();
+    const { updateSchedule, deleteSchedule, loading } = useSchedule();
     const [editSchedule, setEditSchedule] = useRecoilState(scheduleAtom);
     const onChangeTitle = (e: ChangeEvent<HTMLInputElement>) => {
         setEditSchedule({ ...editSchedule, name: e.target.value });
@@ -36,7 +36,9 @@ export const ScheduleEditForm = (props: Props) => {
     const onClickUpdate = () => {
         updateSchedule();
     };
-    const onClickDelete = () => {};
+    const onClickDelete = () => {
+        deleteSchedule();
+    };
     return (
         <>
             <ModalHeader color="font.100" h="80px">

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -36,4 +36,5 @@ Route::group(['middleware' => 'auth:sanctum'], function () {
     Route::get('schedules', 'App\Http\Controllers\ScheduleController@index');
     Route::post('schedule/store', 'App\Http\Controllers\ScheduleController@store');
     Route::put('schedule/update', 'App\Http\Controllers\ScheduleController@update');
+    Route::put('schedule/delete', 'App\Http\Controllers\ScheduleController@delete');
 });


### PR DESCRIPTION
１．スケジュールを削除するAPIを作成しました。
２．useSchedule(hooks)にスケジュールを削除する機能を追加しました。
 Changes to be committed:
	modified:   src/app/Http/Controllers/ScheduleController.php
	modified:   src/resources/ts/components/organisms/gantt/ScheduleEditForm.tsx
	modified:   src/resources/ts/hooks/useSchedule.ts
	modified:   src/routes/api.php