### PR TITLE
fix: show user name of private chat room

### DIFF
--- a/src/resources/ts/components/organisms/chat/ChatRoom.tsx
+++ b/src/resources/ts/components/organisms/chat/ChatRoom.tsx
@@ -20,7 +20,7 @@ export const ChatRoom = (props: Props) => {
             {rooms.map((room) => (
                 <RoomBar
                     key={room.room_id}
-                    userName={`${room.first_name} ${room.last_name}`}
+                    userName={`${room.last_name} ${room.first_name}`}
                     content={(Math.random() * 100).toString()}
                     isRead={true}
                     roomId={room.room_id}


### PR DESCRIPTION
１．チャットルーム中のユーザ名の姓と名前を入れ替えました。
 Changes to be committed:
	modified:   src/resources/ts/components/organisms/chat/ChatRoom.tsx