### PR TITLE
update: test tear down

### DIFF
--- a/src/tests/Feature/Task/createTask.php
+++ b/src/tests/Feature/Task/createTask.php
@@ -9,6 +9,14 @@ use Tests\TestCase;
 
 class createTask extends TestCase
 {
+
+    // テスト終了後にマイグレーションを実行する
+    public function tearDown(): void
+    {
+        parent::setUp();
+        $this->artisan('migrate:refresh --seed');
+    }
+
     /**
      * @test
      */

--- a/src/tests/Feature/Task/getFinishedTask.php
+++ b/src/tests/Feature/Task/getFinishedTask.php
@@ -11,6 +11,14 @@ use Tests\TestCase;
 
 class getFinishedTask extends TestCase
 {
+
+    // テスト終了後にマイグレーションを実行する
+    public function tearDown(): void
+    {
+        parent::setUp();
+        $this->artisan('migrate:refresh --seed');
+    }
+
     /**
      * @test
      */

--- a/src/tests/Feature/Task/getTask.php
+++ b/src/tests/Feature/Task/getTask.php
@@ -12,6 +12,14 @@ use Tests\TestCase;
 
 class getTask extends TestCase
 {
+
+    // テスト終了後にマイグレーションを実行する
+    public function tearDown(): void
+    {
+        parent::setUp();
+        $this->artisan('migrate:refresh --seed');
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
１．テスト終了後に"php artisan migrate:refresh --seed"コマンドを実行するように変更しました。
 Changes to be committed:
	modified:   src/tests/Feature/Task/createTask.php
	modified:   src/tests/Feature/Task/getFinishedTask.php
	modified:   src/tests/Feature/Task/getTask.php